### PR TITLE
feat: 쿠폰 발급 서비스 구현

### DIFF
--- a/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/exception/ErrorCode.java
+++ b/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/exception/ErrorCode.java
@@ -1,8 +1,13 @@
 package com.fastcampus.coupon_core.exception;
 
+import lombok.Getter;
+
+@Getter
 public enum ErrorCode {
     INVALID_COUPON_ISSUE_QUANTITY("발급 가능한 수량을 초과합니다."),
     INVALID_COUPON_ISSUE_DATE("발급 가능한 일자가 아닙니다."),
+    COUPON_NOT_EXIST("쿠폰 정책이 존재하지 않습니다."),
+    DUPLICATED_COUPON_ISSUE("이미 발급된 쿠폰입니다."),
     ;
 
     private final String message;

--- a/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/repository/mysql/CouponIssueJpaRepository.java
+++ b/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/repository/mysql/CouponIssueJpaRepository.java
@@ -1,0 +1,9 @@
+package com.fastcampus.coupon_core.repository.mysql;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fastcampus.coupon_core.model.CouponIssue;
+
+public interface CouponIssueJpaRepository extends JpaRepository<CouponIssue, Long> {
+
+}

--- a/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/repository/mysql/CouponIssueRepository.java
+++ b/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/repository/mysql/CouponIssueRepository.java
@@ -1,0 +1,23 @@
+package com.fastcampus.coupon_core.repository.mysql;
+
+import org.springframework.stereotype.Repository;
+
+import com.fastcampus.coupon_core.model.CouponIssue;
+import com.querydsl.jpa.JPQLQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import static com.fastcampus.coupon_core.model.QCouponIssue.couponIssue;
+
+@RequiredArgsConstructor
+@Repository
+public class CouponIssueRepository {
+
+    private final JPQLQueryFactory queryFactory;
+
+    public CouponIssue findFirstCouponIssue(long couponId, long userId) {
+        return queryFactory.selectFrom(couponIssue)
+            .where(couponIssue.couponId.eq(couponId), couponIssue.userId.eq(userId))
+            .fetchFirst();
+    }
+}

--- a/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/repository/mysql/CouponJpaRepository.java
+++ b/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/repository/mysql/CouponJpaRepository.java
@@ -1,0 +1,9 @@
+package com.fastcampus.coupon_core.repository.mysql;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fastcampus.coupon_core.model.Coupon;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+
+}

--- a/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/service/CouponIssueService.java
+++ b/coupon-management-main/coupon-core/src/main/java/com/fastcampus/coupon_core/service/CouponIssueService.java
@@ -1,0 +1,51 @@
+package com.fastcampus.coupon_core.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fastcampus.coupon_core.exception.CouponIssueException;
+import com.fastcampus.coupon_core.model.Coupon;
+import com.fastcampus.coupon_core.model.CouponIssue;
+import com.fastcampus.coupon_core.repository.mysql.CouponIssueJpaRepository;
+import com.fastcampus.coupon_core.repository.mysql.CouponIssueRepository;
+import com.fastcampus.coupon_core.repository.mysql.CouponJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import static com.fastcampus.coupon_core.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponIssueService {
+    private final CouponIssueRepository couponIssueRepository;
+    private final CouponJpaRepository couponJpaRepository;
+    private final CouponIssueJpaRepository couponIssueJpaRepository;
+
+    @Transactional
+    public void issue(long couponId, long userId) {
+        Coupon coupon = findCoupon(couponId);
+        coupon.issue();
+        saveCouponIssue(couponId, userId);
+    }
+
+    public Coupon findCoupon(long couponId) {
+        return couponJpaRepository.findById(couponId).orElseThrow(() -> {
+            throw new CouponIssueException(COUPON_NOT_EXIST, "쿠폰 정책이 존재하지 않습니다. %s".formatted(couponId));
+        });
+    }
+
+    @Transactional
+    public CouponIssue saveCouponIssue(long couponId, long userId) {
+        checkAlreadyIssuance(couponId, userId);
+        CouponIssue couponIssue = CouponIssue.of(couponId, userId);
+        return couponIssueJpaRepository.save(couponIssue);
+    }
+
+    private void checkAlreadyIssuance(long couponId, long userId) {
+        CouponIssue issue = couponIssueRepository.findFirstCouponIssue(couponId, userId);
+        if (issue != null) {
+            throw new CouponIssueException(DUPLICATED_COUPON_ISSUE, "이미 발급된 쿠폰입니다. user_id: %d, coupon_id: %d".formatted(userId, couponId));
+        }
+    }
+}

--- a/coupon-management-main/coupon-core/src/main/resources/application-core.yml
+++ b/coupon-management-main/coupon-core/src/main/resources/application-core.yml
@@ -22,3 +22,25 @@ spring:
         redis:
             host: localhost
             port: 6380
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: jdbc:h2:mem:test;
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6380

--- a/coupon-management-main/coupon-core/src/test/java/com/fastcampus/coupon_core/TestConfig.java
+++ b/coupon-management-main/coupon-core/src/test/java/com/fastcampus/coupon_core/TestConfig.java
@@ -1,5 +1,14 @@
 package com.fastcampus.coupon_core;
 
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.config.name=application-core")
+@SpringBootTest(classes = CouponCoreConfiguration.class)
 public class TestConfig {
     
 }

--- a/coupon-management-main/coupon-core/src/test/java/com/fastcampus/coupon_core/service/CouponIssueServiceTest.java
+++ b/coupon-management-main/coupon-core/src/test/java/com/fastcampus/coupon_core/service/CouponIssueServiceTest.java
@@ -1,0 +1,178 @@
+package com.fastcampus.coupon_core.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.fastcampus.coupon_core.TestConfig;
+import com.fastcampus.coupon_core.exception.CouponIssueException;
+import com.fastcampus.coupon_core.model.Coupon;
+import com.fastcampus.coupon_core.model.CouponIssue;
+import com.fastcampus.coupon_core.model.CouponType;
+import com.fastcampus.coupon_core.repository.mysql.CouponIssueJpaRepository;
+import com.fastcampus.coupon_core.repository.mysql.CouponIssueRepository;
+import com.fastcampus.coupon_core.repository.mysql.CouponJpaRepository;
+
+import static com.fastcampus.coupon_core.exception.ErrorCode.*;
+
+import java.time.LocalDateTime;
+
+public class CouponIssueServiceTest extends TestConfig {
+    @Autowired
+    private CouponIssueService couponIssueService;
+
+    @Autowired
+    private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private CouponIssueJpaRepository couponIssueJpaRepository;
+
+    @Autowired
+    private CouponIssueRepository couponIssueRepository;
+
+    @BeforeEach
+    void clean() {
+        couponJpaRepository.deleteAllInBatch();
+        couponIssueJpaRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 내역이 존재하면 예외를 반환한다")
+    void saveCouponIssue_1() {
+        // given
+        CouponIssue couponIssue = CouponIssue.builder()
+                .couponId(1L)
+                .userId(1L)
+                .build();
+        couponIssueJpaRepository.save(couponIssue);
+        // when & then
+        CouponIssueException exception = Assertions.assertThrows(CouponIssueException.class, () -> {
+            couponIssueService.saveCouponIssue(couponIssue.getCouponId(), couponIssue.getUserId());
+        });
+        Assertions.assertEquals(exception.getErrorCode(), DUPLICATED_COUPON_ISSUE);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 내역이 존재하지 않는다면 쿠폰을 발급한다")
+    void saveCouponIssue_2() {
+        // given
+        long couponId = 1L;
+        long userId = 1L;
+        // when
+        CouponIssue result = couponIssueService.saveCouponIssue(couponId, userId);
+        // then
+        Assertions.assertTrue(couponIssueJpaRepository.findById(result.getId()).isPresent());
+    }
+
+    @Test
+    @DisplayName("발급 수량, 기한, 중복 발급 문제가 없다면 쿠폰을 발급한다")
+    void issue_1() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        // when
+        couponIssueService.issue(coupon.getId(), userId);
+        // then
+        Coupon couponResult = couponJpaRepository.findById(coupon.getId()).get();
+        Assertions.assertEquals(couponResult.getIssuedQuantity(), 1);
+
+        CouponIssue couponIssueResult = couponIssueRepository.findFirstCouponIssue(coupon.getId(), userId);
+        Assertions.assertNotNull(couponIssueResult);
+    }
+
+
+    @Test
+    @DisplayName("발급 수량에 문제가 있다면 예외를 반환한다")
+    void issue_2() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(100)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        // when & then
+        CouponIssueException exception = Assertions.assertThrows(CouponIssueException.class, () -> {
+            couponIssueService.issue(coupon.getId(), userId);
+        });
+        Assertions.assertEquals(exception.getErrorCode(), INVALID_COUPON_ISSUE_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("발급 기한에 문제가 있다면 예외를 반환한다")
+    void issue_3() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(2))
+                .dateIssueEnd(LocalDateTime.now().minusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        // when & then
+        CouponIssueException exception = Assertions.assertThrows(CouponIssueException.class, () -> {
+            couponIssueService.issue(coupon.getId(), userId);
+        });
+        Assertions.assertEquals(exception.getErrorCode(), INVALID_COUPON_ISSUE_DATE);
+    }
+
+    @Test
+    @DisplayName("중복 발급 검증에 문제가 있다면 예외를 반환한다")
+    void issue_4() {
+        // given
+        long userId = 1;
+        Coupon coupon = Coupon.builder()
+                .couponType(CouponType.FIRST_COME_FIRST_SERVED)
+                .title("선착순 테스트 쿠폰")
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .dateIssueStart(LocalDateTime.now().minusDays(1))
+                .dateIssueEnd(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+
+        CouponIssue couponIssue = CouponIssue.builder()
+                .couponId(coupon.getId())
+                .userId(userId)
+                .build();
+        couponIssueJpaRepository.save(couponIssue);
+
+        // when & then
+        CouponIssueException exception = Assertions.assertThrows(CouponIssueException.class, () -> {
+            couponIssueService.issue(coupon.getId(), userId);
+        });
+        Assertions.assertEquals(exception.getErrorCode(), DUPLICATED_COUPON_ISSUE);
+    }
+
+    @Test
+    @DisplayName("쿠폰이 존재하지 않는다면 예외를 반환한다")
+    void issue_5() {
+        // given
+        long userId = 1;
+        long couponId = 1;
+
+        // when & then
+        CouponIssueException exception = Assertions.assertThrows(CouponIssueException.class, () -> {
+            couponIssueService.issue(couponId, userId);
+        });
+        Assertions.assertEquals(exception.getErrorCode(), COUPON_NOT_EXIST);
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #5

## ✨ PR 작업 내용

- 쿠폰 발급 서비스(CouponIssueService) 구현
- 쿠폰 및 발급 내역 리포지토리 레이어 구현 (JPA, QueryDSL)
- 쿠폰 발급 관련 예외 케이스 추가 (중복 발급, 쿠폰 미존재)
- 테스트 환경 설정 (H2 인메모리 DB, 테스트 프로필) 
- 서비스 레이어 단위 테스트 작성

## 🤔 작업 배경 및 고민 과정
본 내용은 패스트캠퍼스 강의 내용입니다.

## 이미지 첨부

<img src="파일 주소" width="50%" height="50%">
<br/>

## 다음 할 일

- 다음으로 할 일을 작성해 주세요.
